### PR TITLE
Upgrading to 0.16.0

### DIFF
--- a/02_1_Setting_Up_a_Bitcoin-Core_VPS_by_Hand.md
+++ b/02_1_Setting_Up_a_Bitcoin-Core_VPS_by_Hand.md
@@ -256,10 +256,10 @@ We find a number of Bash aliases helpful to make it easier to use Bitcoin.
 ```
 $ sudo -u user1 cat >> ~user1/.bash_profile <<EOF
 alias btcdir="cd ~/.bitcoin/" #linux default bitcoind path
-alias bc="bitcoin-cli"
-alias bd="bitcoind"
-alias btcinfo='bitcoin-cli getwalletinfo | egrep "\"balance\""; bitcoin-cli getinfo | egrep "\"version\"|connections"; bitcoin-cli getmininginfo | egrep "\"blocks\"|errors"'
-alias btcblock="echo \\\`bitcoin-cli getblockcount 2>&1\\\`/\\\`wget -O - http://blockexplorer.com/testnet/q/getblockcount 2> /dev/null | cut -d : -f2 | rev | cut -c 2- | rev\\\`"
+alias bt="bitcoin-cli -testnet"
+alias btd="bitcoind -testnet"
+alias btinfo='bitcoin-cli -testnet getwalletinfo | egrep "\"balance\""; bitcoin-cli -testnet -getinfo | egrep "\"version\"|connections"; bitcoin-cli getmininginfo | egrep "\"blocks\"|errors"'
+alias btblock="echo \\\`bitcoin-cli -testnet getblockcount 2>&1\\\`/\\\`wget -O - https://blockexplorer.com/testnet/q/getblockcount 2> /dev/null | cut -d : -f2 | rev | cut -c 2- | rev\\\`"
 EOF
 ```
 
@@ -268,9 +268,9 @@ EOF
 $ sudo -u user1 cat >> ~user1/.bash_profile <<EOF
 alias btcdir="cd ~/.bitcoin/" #linux default bitcoind path
 alias bc="bitcoin-cli"
-alias bd="bitcoind"
-alias btcinfo='bitcoin-cli getwalletinfo | egrep "\"balance\""; bitcoin-cli getinfo | egrep "\"version\"|connections"; bitcoin-cli getmininginfo | egrep "\"blocks\"|errors"'
-alias btcblock="echo \\\`bitcoin-cli getblockcount 2>&1\\\`/\\\`wget -O - http://blockchain.info/q/getblockcount 2>/dev/null\\\`"
+alias bcd="bitcoind"
+alias bcinfo='bitcoin-cli getwalletinfo | egrep "\"balance\""; bitcoin-cli -getinfo | egrep "\"version\"|connections"; bitcoin-cli getmininginfo | egrep "\"blocks\"|errors"'
+alias bcblock="echo \\\`bitcoin-cli getblockcount 2>&1\\\`/\\\`wget -O - https://blockexplorer.com/q/getblockcount 2>/dev/null\\\`"
 EOF
 ```
 
@@ -294,9 +294,9 @@ $ source ~/.bash_profile
 
 We suggest setting up two variables to make this installation more automatic.
 
-The first variable, $BITCOIN, should be set to the current version of Bitcoin. It was 0.15.1 when we wrote this. The second will then automatically generate a truncated form used by some of the files.
+The first variable, $BITCOIN, should be set to the current version of Bitcoin. It was 0.16.0 when we wrote this. The second will then automatically generate a truncated form used by some of the files.
 ```
-$ export BITCOIN=bitcoin-core-0.15.1
+$ export BITCOIN=bitcoin-core-0.16.0
 $ export BITCOINPLAIN=`echo $BITCOIN | sed 's/bitcoin-core/bitcoin/'`
 ```
 
@@ -388,9 +388,9 @@ So now you probably want to play with Bitcoin!
 
 But wait, your Bitcoin daemon is probably still downloading blocks. This alias, from your .bash configuration will tell you how things are going:
 ```
-$ btcblock
+$ btblock
 ```
-0.15.1 is quite fast to download blocks, but it might still take an hour to download the unpruned testnet. It might be time for a few more espressos.
+0.16.0 is quite fast to download blocks, but it might still take an hour to download the unpruned testnet. It might be time for a few more espressos.
 
 > **TESTNET vs MAINNET:** An unpruned mainnet will take hours longer.
 

--- a/02_2_Setting_Up_a_Bitcoin-Core_VPS_with_StackScript.md
+++ b/02_2_Setting_Up_a_Bitcoin-Core_VPS_with_StackScript.md
@@ -148,7 +148,7 @@ You will know the StackScripts are done when a BITCOIN-IS-READY file appears in 
 
 ```
 $ ls
-bitcoin-0.15.1-x86_64-linux-gnu.tar.gz    laanwj-releases.asc
+bitcoin-0.16.0-x86_64-linux-gnu.tar.gz    laanwj-releases.asc
 BITCOIN-IS-READY            SHA256SUMS.asc
 ```
 

--- a/02_2__Script_Linode_Setup.stackscript
+++ b/02_2__Script_Linode_Setup.stackscript
@@ -23,7 +23,7 @@
 # CURRENT BITCOIN RELEASE:
 # Change as necessary
 
-export BITCOIN=bitcoin-core-0.15.1
+export BITCOIN=bitcoin-core-0.16.0
 
 # Set the variable $IPADDR to the IP address the new Linode receives.
 IPADDR=$(/sbin/ifconfig eth0 | awk '/inet / { print $2 }' | sed 's/addr://')
@@ -182,10 +182,10 @@ if [ "$BTCTYPE" == "Testnet" ] || [ "$BTCTYPE" == "Pruned Testnet" ]; then
 sudo -u user1 cat >> ~user1/.bash_profile <<EOF
 alias btcdir="cd ~/.bitcoin/" #linux default bitcoind path
         # alias btcdir="cd ~/Library/Application\ Support/Bitcoin/" #mac default bitcoind path
-alias bc="bitcoin-cli"
-alias bd="bitcoind"
-alias btcinfo='bitcoin-cli getwalletinfo | egrep "\"balance\""; bitcoin-cli getinfo | egrep "\"version\"|connections"; bitcoin-cli getmininginfo | egrep "\"blocks\"|errors"'
-alias btcblock="echo \\\`bitcoin-cli getblockcount 2>&1\\\`/\\\`wget -O - http://blockexplorer.com/testnet/q/getblockcount 2> /dev/null | cut -d : -f2 | rev | cut -c 2- | rev\\\`"
+alias bt="bitcoin-cli -testnet"
+alias btd="bitcoind -testnet"
+alias btinfo='bitcoin-cli -testnet getwalletinfo | egrep "\"balance\""; bitcoin-cli -testnet -getinfo | egrep "\"version\"|connections"; bitcoin-cli getmininginfo | egrep "\"blocks\"|errors"'
+alias btblock="echo \\\`bitcoin-cli -testnet getblockcount 2>&1\\\`/\\\`wget -O - https://blockexplorer.com/testnet/q/getblockcount 2> /dev/null | cut -d : -f2 | rev | cut -c 2- | rev\\\`"
 EOF
 
 else
@@ -194,9 +194,9 @@ sudo -u user1 cat >> ~user1/.bash_profile <<EOF
 alias btcdir="cd ~/.bitcoin/" #linux default bitcoind path
         # alias btcdir="cd ~/Library/Application\ Support/Bitcoin/" #mac default bitcoind path
 alias bc="bitcoin-cli"
-alias bd="bitcoind"
-alias btcinfo='bitcoin-cli getwalletinfo | egrep "\"balance\""; bitcoin-cli getinfo | egrep "\"version\"|connections"; bitcoin-cli getmininginfo | egrep "\"blocks\"|errors"'
-alias btcblock="echo \\\`bitcoin-cli getblockcount 2>&1\\\`/\\\`wget -O - http://blockchain.info/q/getblockcount 2>/dev/null\\\`"
+alias bcd="bitcoind"
+alias bcinfo='bitcoin-cli getwalletinfo | egrep "\"balance\""; bitcoin-cli -getinfo | egrep "\"version\"|connections"; bitcoin-cli getmininginfo | egrep "\"blocks\"|errors"'
+alias bcblock="echo \\\`bitcoin-cli getblockcount 2>&1\\\`/\\\`wget -O - https://blockexplorer.com/q/getblockcount 2>/dev/null\\\`"
 EOF
 
 fi

--- a/03_2_Knowing_Your_Bitcoin_Setup.md
+++ b/03_2_Knowing_Your_Bitcoin_Setup.md
@@ -50,13 +50,14 @@ gettxoutproof ["txid",...] ( blockhash )
 gettxoutsetinfo
 preciousblock "blockhash"
 pruneblockchain
+savemempool
 verifychain ( checklevel nblocks )
 verifytxoutproof "proof"
 
 == Control ==
-getinfo
 getmemoryinfo ("mode")
 help ( "command" )
+logging ( <include> <exclude> )
 stop
 uptime
 
@@ -88,16 +89,16 @@ setnetworkactive true|false
 == Rawtransactions ==
 combinerawtransaction ["hexstring",...]
 createrawtransaction [{"txid":"id","vout":n},...] {"address":amount,"data":"hex",...} ( locktime ) ( replaceable )
-decoderawtransaction "hexstring"
+decoderawtransaction "hexstring" ( iswitness )
 decodescript "hexstring"
-fundrawtransaction "hexstring" ( options )
-getrawtransaction "txid" ( verbose )
+fundrawtransaction "hexstring" ( options iswitness )
+getrawtransaction "txid" ( verbose "blockhash" )
 sendrawtransaction "hexstring" ( allowhighfees )
 signrawtransaction "hexstring" ( [{"txid":"id","vout":n,"scriptPubKey":"hex","redeemScript":"hex"},...] ["privatekey1",...] sighashtype )
+signrawtransactionwithkey "hexstring" ["privatekey1",...] ( [{"txid":"id","vout":n,"scriptPubKey":"hex","redeemScript":"hex"},...] sighashtype )
 
 == Util ==
 createmultisig nrequired ["key",...]
-estimatefee nblocks
 estimatesmartfee conf_target ("estimate_mode")
 signmessagewithprivkey "privkey" "message"
 validateaddress "address"
@@ -106,8 +107,7 @@ verifymessage "address" "signature" "message"
 == Wallet ==
 abandontransaction "txid"
 abortrescan
-addmultisigaddress nrequired ["key",...] ( "account" )
-addwitnessaddress "address"
+addmultisigaddress nrequired ["key",...] ( "account" "address_type" )
 backupwallet "destination"
 bumpfee "txid" ( options )
 dumpprivkey "address"
@@ -116,9 +116,10 @@ encryptwallet "passphrase"
 getaccount "address"
 getaccountaddress "account"
 getaddressesbyaccount "account"
+getaddressinfo "address"
 getbalance ( "account" minconf include_watchonly )
-getnewaddress ( "account" )
-getrawchangeaddress
+getnewaddress ( "account" "address_type" )
+getrawchangeaddress ( "address_type" )
 getreceivedbyaccount "account" ( minconf )
 getreceivedbyaddress "address" ( minconf )
 gettransaction "txid" ( include_watchonly )
@@ -143,12 +144,17 @@ listwallets
 lockunspent unlock ([{"txid":"txid","vout":n},...])
 move "fromaccount" "toaccount" amount ( minconf "comment" )
 removeprunedfunds "txid"
+rescanblockchain ("start_height") ("stop_height")
 sendfrom "fromaccount" "toaddress" amount ( minconf "comment" "comment_to" )
 sendmany "fromaccount" {"address":amount,...} ( minconf "comment" ["address",...] replaceable conf_target "estimate_mode")
 sendtoaddress "address" amount ( "comment" "comment_to" subtractfeefromamount replaceable conf_target "estimate_mode")
 setaccount "address" "account"
 settxfee amount
 signmessage "address" "message"
+signrawtransactionwithwallet "hexstring" ( [{"txid":"id","vout":n,"scriptPubKey":"hex","redeemScript":"hex"},...] sighashtype )
+walletlock
+walletpassphrase "passphrase" timeout
+walletpassphrasechange "oldpassphrase" "newpassphrase"
 ```
 You can also type `bitcoin help [command]` to get even more extensive info on that command. For example:
 ```
@@ -159,15 +165,13 @@ Returns a json object containing mining-related information.
 Result:
 {
   "blocks": nnn,             (numeric) The current block
-  "currentblocksize": nnn,   (numeric) The last block size
   "currentblockweight": nnn, (numeric) The last block weight
   "currentblocktx": nnn,     (numeric) The last block transaction
   "difficulty": xxx.xxxxx    (numeric) The current difficulty
-  "errors": "..."            (string) Current errors
   "networkhashps": nnn,      (numeric) The network hashes per second
   "pooledtx": n              (numeric) The size of the mempool
-  "testnet": true|false      (boolean) If using testnet or not
   "chain": "xxxx",           (string) current network name as defined in BIP70 (main, test, regtest)
+  "warnings": "..."          (string) any network and blockchain warnings
 }
 
 Examples:

--- a/03_3_Setting_Up_Your_Wallet.md
+++ b/03_3_Setting_Up_Your_Wallet.md
@@ -36,7 +36,9 @@ Sometimes you'll need to prove that you control a Bitcoin address (or rather, th
 $ bitcoin-cli signmessage "n4cqjJE6fqcmeWpftygwPoKMMDva6BpyHf" "Hello, World"
 H3yMBZaFeSmG2HgnH38dImzZAwAQADcOiMKTC1fryoV6Y93BelqzDMTCqNcFoik86E8qHa6o3FCmTsxWD7Wa5YY=
 ```
-You'll get the signature as a return.
+You'll get the signature as a return. 
+
+Note that `signmessage`/`verifymessage` with Bitcoin Core 0.16.0 currently doesn't support segwit addresses, so you will have to generate a legacy address for this exercise.
 
 _What is a signature?_ A digital signature is a combination of a message and a private key that can then be unlocked with a public key. Since there's a one-to-one correspendence between the elements of a keypair, unlocking with a public key proves that the signer controlled the corresponding private key. 
 

--- a/03_3_Setting_Up_Your_Wallet.md
+++ b/03_3_Setting_Up_Your_Wallet.md
@@ -6,20 +6,24 @@ You're now ready to start working with Bitcoin. To begin with, you'll need to cr
 
 ## Create an Address
 
-The first thing you need to do is create an address for receiving payments. This is done with the `bitcoin-cli getnewaddress` command. Remember that if you want more information on this command, you should type `bitcoin-cli help getnewaddress`.
+The first thing you need to do is create an address for receiving payments. This is done with the `bitcoin-cli getnewaddress` command. Remember that if you want more information on this command, you should type `bitcoin-cli help getnewaddress`. Bitcoin Core 0.16.0 gives p2sh-segwit as default address, this can be changed by `-addresstype`. Otherwise, you can specify the address type between "legacy", "p2sh-segwit", and "bech32".
 ```
-$ bitcoin-cli getnewaddress
+$ bitcoin-cli getnewaddress "" "legacy"
 n4cqjJE6fqcmeWpftygwPoKMMDva6BpyHf
+$ bitcoin-cli getnewaddress "" "p2sh-segwit"
+2N2ep3jgQ5gLmsDQhHVTaaqmC4rupNrJa2v
+$ bitcoin-cli getnewaddress "" "bech32"
+tb1qpdv9q35k7hwvewd2v38ylfuhhaewdfl40ptsn0
 ```
-Note that this address begins with an "n" (or sometimes an "m"). This signifies that this is a testnet address. 
+Note that this address begins with an "n", "m", "2" or "tb1"). This signifies that this is a testnet address. 
 
-> **TESTNET vs MAINNET:** The equivalent mainnet address would start with a 1.
+> **TESTNET vs MAINNET:** The equivalent mainnet address would start with a "1", "3", "bc1"
 
 Take careful note of the address. You'll need to give it to whomever will be sending you funds.
 
 _What is a Bitcoin address?_ A Bitcoin address is literally where you receive money. It's like an email address, but for funds. However unlike an email address, a Bitcoin address should be considered single use: use it to receive funds just _once_. When you want to receive funds from someone else or at some other time, generate a new address. This is suggested in large part to improve your privacy. The whole blockchain is immutable, which means that explorers can look at long chains of transactions over time, making it possible to statistically determine who you and your contacts are, no matter how careful you are. However, if you keep reusing the same address, then this becomes even easier.
 
-_What is a P2PKH address?_ A Bitcoin address is also something else: a public key (or more precisely, the 160-bit hash of a public key). For this reason it's called a Pay to PubKey Hash (or P2PKH) address. This public key of your key pair allows you to receive money, while an associated private key lets you spend that money. However, bitcoins may be sent to other sorts of addresses: Pay to Script Hash (P2SH) addresses feature prominently in the latter part of this tutorial.
+_What is a P2PKH address?_ A Bitcoin address is also something else: a public key (or more precisely, the 160-bit hash of a public key). For this reason it's called a Pay to PubKey Hash (or P2PKH) address. This public key of your key pair allows you to receive money, while an associated private key lets you spend that money. However, bitcoins may be sent to other sorts of addresses: Pay to Script Hash (P2SH) and Native Segwit (Bech32) addresses feature prominently in the latter part of this tutorial.
 
 _What is a Bitcoin wallet?_ By creating your first Bitcoin address, you've also begun to fill in your Bitcoin wallet. More precisely, you've begun to fill the `wallet.dat` file in your ~/.bitcoin/testnet3 directory. The `wallet.dat` file contains data about preferences and transactions, but more importantly it contains all of the key pairs that you create: both the public key (which is the source of the address where you receive funds) and the private key (which is how you spend those funds). For the most part, you won't have to worry about that private key: `bitcoind` will use it when it's needed. However, this makes the `wallet.dat` file extremely important: if you lose it, you lose your private keys, and if you lose your private keys, you lose your funds!
 


### PR DESCRIPTION
Chapter 2 setup changes including: getinfo is deprecated, so use -getinfo for bcinfo. Also, added different commands for testnet vs mainnet for bash profile.