### PR TITLE
increase recommended storage and fix a few typos

### DIFF
--- a/02_1_Setting_Up_a_Bitcoin-Core_VPS_by_Hand.md
+++ b/02_1_Setting_Up_a_Bitcoin-Core_VPS_by_Hand.md
@@ -33,15 +33,15 @@ If your cloud provider offers two-factor authentication for their web tools, we 
 
 ### Create a Machine
 
-You should now create your Bitcoin VPS. For an Unpruned Testnet setup, you should have at least 2-3G of memory and at least 15G of storage.
+You should now create your Bitcoin VPS. For an Unpruned Testnet setup, you should have at least 2-3G of memory and at least 19G of storage.
 
 > **WARNING:** We've occasionally had machines run out of memory after running `bitcoind` for a few days when they only had 2G. Coming back, we find that `bitcoind` has stopped, leaving the message "Error: Out of memory. Terminating." in the `debug.log` file. This simply requires a restart of `bitcoind` and ten or fifteen minutes to get the blockchain resynced. Be generous with your memory if you want to avoid this annoyance, but don't worry too much if you hit it.
 
-We also suggest that you choose a Debian 9 image when you're creating your machine. These commands were all tested on Debian 9.5 (jessie). The further you get away from that, the less likely things will work as described here. So, another Debian is probably OK and maybe a different Ubuntu, but we've tried these out on a Mac, and we know that it's missing some commands like "wget". So, installer beware!
+We also suggest that you choose a Debian 9 image when you're creating your machine. These commands were all tested on Debian 9.5 (stretch). The further you get away from that, the less likely things will work as described here. So, another Debian is probably OK and maybe a different Ubuntu, but we've tried these out on a Mac, and we know that it's missing some commands like "wget". So, installer beware!
 
 Afterward, boot your VPS.
 
-> **TESTNET vs MAINNET:** The various possible setups require 5-15G of storage and 2-3G of memory. The non-Pruned Mainnet is the only setup that requires considerably more: about 170G of storage to hold the current blockchain.
+> **TESTNET vs MAINNET:** The various possible setups require 5-19G of storage and 2-3G of memory. The non-Pruned Mainnet is the only setup that requires considerably more: about 170G of storage to hold the current blockchain.
 >
 > Following are suggestions for machine requirements:
 >
@@ -49,7 +49,7 @@ Afterward, boot your VPS.
 > |-------|--------|---------|
 > | Mainnet | 2-3G | 170G |
 > | Pruned Mainnet | 2-3G | ~5G |
-> | Testnet | 2-3G | ~15G |
+> | Testnet | 2-3G | ~19G |
 > | Pruned Testnet | 2-3G | ~5G |
 > | Regtest | 2-3G | ~ |
 

--- a/04_4__Interlude_Using_Curl.md
+++ b/04_4__Interlude_Using_Curl.md
@@ -14,7 +14,7 @@ In order to use `curl` with `bitcoind`, you must know three things: the standard
 
 ### Know Your Format
 
-The `bitcoin-cli` commands are all linked to RPC commands in `bitcoind`. That makes the transition from using `bitcoin-cli` to using `curl` very simple. In fact, if you look at any of the help pages for `bitcoin-cli`, you'll see that they list not only the `bitcoin-cli` commands, but also parallel `curl` commands. For example, here is `bitcoin-cli getinfo help`:
+The `bitcoin-cli` commands are all linked to RPC commands in `bitcoind`. That makes the transition from using `bitcoin-cli` to using `curl` very simple. In fact, if you look at any of the help pages for `bitcoin-cli`, you'll see that they list not only the `bitcoin-cli` commands, but also parallel `curl` commands. For example, here is `bitcoin-cli help getmininginfo`:
 ```
 $ bitcoin-cli help getmininginfo
 getmininginfo

--- a/15_1_Accessing_Bitcoind_with_C.md
+++ b/15_1_Accessing_Bitcoind_with_C.md
@@ -23,11 +23,16 @@ Before you can compile and install the package, you'll probably need to adjust y
 ```
 $ PATH="/sbin:$PATH"
 ```
-For a Ubunto system, you'll also want to adjust the `INSTALL_LIBPATH` in the `libbitcoinrpc` `Makefile` to install to `/usr/lib` instead of `/usr/local/lib`:
+For an Ubuntu system, you'll also want to adjust the `INSTALL_LIBPATH` in the `libbitcoinrpc` `Makefile` to install to `/usr/lib` instead of `/usr/local/lib`:
 ```
 INSTALL_LIBPATH    := $(INSTALL_PREFIX)/usr/lib
 ```
 (If you prefer not to sully your `/usr/lib`, the alternative is to change your `etc/ld.so.conf` or its dependent files appropriately ... but for a test setup on a test machine, this is probably fine.)
+
+Likewise, you'll also want to adjust the `INSTALL_HEADERPATH` in the `libbitcoinrpc` `Makefile` to install to `/usr/include` instead of `/usr/local/include`:
+```
+INSTALL_HEADERPATH    := $(INSTALL_PREFIX)/usr/include
+```
 
 Then you can compile:
 ```


### PR DESCRIPTION
I used your instructions to create unpruned testnet installs in debian 8, 9 and ubuntu 16.04. Everything went great, but I did find a few typos in the pages--fixed in this PR. I also updated the recommended storage needed for the unpruned testnet to 19GB, as my copy is currently using about 18GB and growing.