### PR TITLE
Fix/update the `btcinfo` bash alias

### DIFF
--- a/03_1_Verifying_Your_Bitcoin_Setup.md
+++ b/03_1_Verifying_Your_Bitcoin_Setup.md
@@ -13,7 +13,7 @@ cat >> ~/.bash_profile <<EOF
 alias btcdir="cd ~/.bitcoin/" #linux default bitcoind path
 alias bc="bitcoin-cli"
 alias bd="bitcoind"
-alias btcinfo='bitcoin-cli getwalletinfo | egrep "\"balance\""; bitcoin-cli getnetworkinfo | egrep "\"version\"|connections"; bitcoin-cli getmininginfo | egrep "\"blocks\"|errors"'
+alias btcinfo='bitcoin-cli -getinfo | egrep "\"version\"|\"balance\"|\"connections\"" && bitcoin-cli getmininginfo | egrep "\"blocks\"|\"errors\""'
 alias btcblock="echo \\\`bitcoin-cli getblockcount 2>&1\\\`/\\\`wget -O - http://blockexplorer.com/testnet/q/getblockcount 2> /dev/null | cut -d : -f2 | rev | cut -c 2- | rev\\\`"
 EOF
 ```


### PR DESCRIPTION
as per current Bitcoin master.

`getwalletinfo` appears to no longer be part of bitcoin-cli, but we can obtain the balance as well as the version and number of connections with `-getinfo` instead.

This commit also improves the terminal output for more consistent coloring of the double quotes.

Further suggestions welcome.