### PR TITLE
update url used to determine current block height

### DIFF
--- a/02_1_Setting_Up_a_Bitcoin-Core_VPS_by_Hand.md
+++ b/02_1_Setting_Up_a_Bitcoin-Core_VPS_by_Hand.md
@@ -260,7 +260,7 @@ alias btcdir="cd ~/.bitcoin/" #linux default bitcoind path
 alias bc="bitcoin-cli"
 alias bd="bitcoind"
 alias btcinfo='bitcoin-cli getwalletinfo | egrep "\"balance\""; bitcoin-cli getinfo | egrep "\"version\"|connections"; bitcoin-cli getmininginfo | egrep "\"blocks\"|errors"'
-alias btcblock="echo \\\`bitcoin-cli getblockcount 2>&1\\\`/\\\`wget -O - http://blockexplorer.com/testnet/q/getblockcount 2> /dev/null | cut -d : -f2 | rev | cut -c 2- | rev\\\`"
+alias btcblock="echo \\\`bitcoin-cli getblockcount 2>&1\\\`/\\\`curl -s https://testnet.blockchain.info/q/getblockcount 2>/dev/null \\\`"
 EOF
 ```
 
@@ -271,7 +271,7 @@ alias btcdir="cd ~/.bitcoin/" #linux default bitcoind path
 alias bc="bitcoin-cli"
 alias bd="bitcoind"
 alias btcinfo='bitcoin-cli getwalletinfo | egrep "\"balance\""; bitcoin-cli getinfo | egrep "\"version\"|connections"; bitcoin-cli getmininginfo | egrep "\"blocks\"|errors"'
-alias btcblock="echo \\\`bitcoin-cli getblockcount 2>&1\\\`/\\\`wget -O - http://blockchain.info/q/getblockcount 2>/dev/null\\\`"
+alias btcblock="echo \\\`bitcoin-cli getblockcount 2>&1\\\`/\\\`curl -s https://blockchain.info/q/getblockcount 2>/dev/null \\\`"
 EOF
 ```
 

--- a/02_2__Script_Linode_Setup.stackscript
+++ b/02_2__Script_Linode_Setup.stackscript
@@ -186,7 +186,7 @@ alias btcdir="cd ~/.bitcoin/" #linux default bitcoind path
 alias bc="bitcoin-cli"
 alias bd="bitcoind"
 alias btcinfo='bitcoin-cli getwalletinfo | egrep "\"balance\""; bitcoin-cli getnetworkinfo | egrep "\"version\"|connections"; bitcoin-cli getmininginfo | egrep "\"blocks\"|errors"'
-alias btcblock="echo \\\`bitcoin-cli getblockcount 2>&1\\\`/\\\`wget -O - http://blockexplorer.com/testnet/q/getblockcount 2> /dev/null | cut -d : -f2 | rev | cut -c 2- | rev\\\`"
+alias btcblock="echo \\\`bitcoin-cli getblockcount 2>&1\\\`/\\\`curl -s https://testnet.blockchain.info/q/getblockcount 2>/dev/null \\\`"
 EOF
 
 else
@@ -197,7 +197,7 @@ alias btcdir="cd ~/.bitcoin/" #linux default bitcoind path
 alias bc="bitcoin-cli"
 alias bd="bitcoind"
 alias btcinfo='bitcoin-cli getwalletinfo | egrep "\"balance\""; bitcoin-cli getinfo | egrep "\"version\"|connections"; bitcoin-cli getmininginfo | egrep "\"blocks\"|errors"'
-alias btcblock="echo \\\`bitcoin-cli getblockcount 2>&1\\\`/\\\`wget -O - http://blockchain.info/q/getblockcount 2>/dev/null\\\`"
+alias btcblock="echo \\\`bitcoin-cli getblockcount 2>&1\\\`/\\\`curl -s https://blockchain.info/q/getblockcount 2>/dev/null \\\`"
 EOF
 
 fi

--- a/03_1_Verifying_Your_Bitcoin_Setup.md
+++ b/03_1_Verifying_Your_Bitcoin_Setup.md
@@ -14,7 +14,7 @@ alias btcdir="cd ~/.bitcoin/" #linux default bitcoind path
 alias bc="bitcoin-cli"
 alias bd="bitcoind"
 alias btcinfo='bitcoin-cli getwalletinfo | egrep "\"balance\""; bitcoin-cli getnetworkinfo | egrep "\"version\"|connections"; bitcoin-cli getmininginfo | egrep "\"blocks\"|errors"'
-alias btcblock="echo \\\`bitcoin-cli getblockcount 2>&1\\\`/\\\`wget -O - http://blockexplorer.com/testnet/q/getblockcount 2> /dev/null | cut -d : -f2 | rev | cut -c 2- | rev\\\`"
+alias btcblock="echo \\\`bitcoin-cli getblockcount 2>&1\\\`/\\\`curl -s https://testnet.blockchain.info/q/getblockcount 2>/dev/null \\\`"
 EOF
 ```
 
@@ -24,7 +24,7 @@ Note that these aliases includes shortcuts for running `bitcoin-cli`, for runnin
 
 With that said, use of these aliases in _this_ document might accidentally obscure the core lessons being taught about Bitcoin, so the only aliases directly used here are `btcinfo` and `btcblock`, because they encapsulate much longer and more complex commands. Otherwise, we show the full commands; adjust for your own use as appropriate.
 
-> **TESTNET vs MAINNET:** Remember that this tutorial generally assumes that you are using testnet. The `btcblock` alias needs to be slightly different on mainnet, where you can use the simpler "wget -O - http://blockchain.info/q/getblockcount 2>/dev/null".
+> **TESTNET vs MAINNET:** Remember that this tutorial generally assumes that you are using testnet. The `btcblock` alias needs to be slightly different on mainnet, where you can use the simpler "curl -s https://blockchain.info/q/getblockcount 2>/dev/null".
 
 ## Run Bitcoind
 


### PR DESCRIPTION
`http://blockexplorer.com/testnet/q/getblockcount` seems to be outdated and can be replaced with `https://testnet.blockchain.info/q/getblockcount` instead.