### PR TITLE
fix current testnet block height

### DIFF
--- a/02_1_Setting_Up_a_Bitcoin-Core_VPS_by_Hand.md
+++ b/02_1_Setting_Up_a_Bitcoin-Core_VPS_by_Hand.md
@@ -260,7 +260,7 @@ alias btcdir="cd ~/.bitcoin/" #linux default bitcoind path
 alias bc="bitcoin-cli"
 alias bd="bitcoind"
 alias btcinfo='bitcoin-cli getwalletinfo | egrep "\"balance\""; bitcoin-cli getinfo | egrep "\"version\"|connections"; bitcoin-cli getmininginfo | egrep "\"blocks\"|errors"'
-alias btcblock="echo \\\`bitcoin-cli getblockcount 2>&1\\\`/\\\`wget -O - http://blockexplorer.com/testnet/q/getblockcount 2> /dev/null | cut -d : -f2 | rev | cut -c 2- | rev\\\`"
+alias btcblock="echo \\\`bitcoin-cli getblockcount 2>&1\\\`/\\\`wget -qO- https://api.blockchair.com/bitcoin/testnet/stats | sed -nr '/\"blocks\":/ s/.*\"blocks\":([^,]+).*/\1/p'\\\`"
 EOF
 ```
 

--- a/03_1_Verifying_Your_Bitcoin_Setup.md
+++ b/03_1_Verifying_Your_Bitcoin_Setup.md
@@ -14,7 +14,7 @@ alias btcdir="cd ~/.bitcoin/" #linux default bitcoind path
 alias bc="bitcoin-cli"
 alias bd="bitcoind"
 alias btcinfo='bitcoin-cli getwalletinfo | egrep "\"balance\""; bitcoin-cli getnetworkinfo | egrep "\"version\"|connections"; bitcoin-cli getmininginfo | egrep "\"blocks\"|errors"'
-alias btcblock="echo \\\`bitcoin-cli getblockcount 2>&1\\\`/\\\`wget -O - http://blockexplorer.com/testnet/q/getblockcount 2> /dev/null | cut -d : -f2 | rev | cut -c 2- | rev\\\`"
+alias btcblock="echo \\\`bitcoin-cli getblockcount 2>&1\\\`/\\\`wget -qO- https://api.blockchair.com/bitcoin/testnet/stats | sed -nr '/\"blocks\":/ s/.*\"blocks\":([^,]+).*/\1/p'\\\`"
 EOF
 ```
 


### PR DESCRIPTION
- Replacing the old testnet url with the blockchair tesnet API. Because the blockexplorer testnet url is no longer available.
- Also added sed command for parsing the output json.

Note: The parsing could be made a lot simpler with jq. But the tutorial has not introduced jq at this point, so sed is used for parsing the output.