### PR TITLE
Update 03_3__Interlude_Using_Command-Line_Variables.md to use the "legacy" option in getnewaddress

### DIFF
--- a/03_3__Interlude_Using_Command-Line_Variables.md
+++ b/03_3__Interlude_Using_Command-Line_Variables.md
@@ -13,7 +13,7 @@ That's a simple command substitution, the equivalent to ``VARIABLE=`command` ``.
 To create a new address would then look like this:
 ```
 $ unset NEW_ADDRESS_1
-$ NEW_ADDRESS_1=$(bitcoin-cli getnewaddress)
+$ NEW_ADDRESS_1=$(bitcoin-cli getnewaddress "" legacy)
 ```
 These commands clear the NEW_ADDRESS_1 variable, just to be sure, then fill it with the results of the `bitcoin-cli getnewaddress` command.
 


### PR DESCRIPTION
As explained in previous file of this book, if the "legacy" option is not used, the signature can't be made.

$ NEW_ADDRESS_1=$(bitcoin-cli getnewaddress)
$ echo $NEW_ADDRESS_1
2MxuvthTutriscciS5WkjixoMDneEizSwVW
$ NEW_SIG_1=$(bitcoin-cli signmessage $NEW_ADDRESS_1 "Hello World")
error code: -3
error message:
Address does not refer to key

---

$ NEW_ADDRESS_1=$(bitcoin-cli getnewaddress "" legacy)
$ NEW_SIG_1=$(bitcoin-cli signmessage $NEW_ADDRESS_1 "Hello World")
$ echo $NEW_SIG_1
IF64znYX95QqSemeI5//cbGQwmMt1AfQ/2ANq6tc2j6WWyC66N85Koieu68qZXdkhmuRsnLrwmoGO90sRj1Ju7A=

