### PR TITLE
Update links in chapter 14.3

### DIFF
--- a/14_3_Adding_SSH_Hidden_Services.md
+++ b/14_3_Adding_SSH_Hidden_Services.md
@@ -54,6 +54,12 @@ Now that you've got Tor installed and know how to use it, you can add other serv
 
 > :fire: ***What's the power of Other Hidden Services?*** Every time you access a service on your server remotely, you leave footprints on the network. Even if the data is encrypted by something like SSH (or TLS), lurkers on the network can see where you're connecting from, where you're connecting to, and what service you're using. Does this matter? This is the question you have to ask. But if the answer is "Yes", you can protect the connection with a hidden service.
 
-Move on to "Programming with RPC" with [Chapter Sixteen: Talking to Bitcoind with C](16_0_Talking_to_Bitcoind.md).
+## What's Next?
 
-Or, if you're not a programmer, you can skip to [Chapter Nineteen: Understanding Your Lightning Setup](19_0_Understanding_Your_Lightning_Setup.md) to continue your command-line education with the Lightning Network.
+Move on to "Using i2p" with [Chapter Fifteen: Using i2p](15_0_Using_i2p.md).
+
+Or, if you prefer, there are two alternate paths:
+
+If you want to stay focused on Bitcoin, move on to "Programming with RPC" with [Chapter Sixteen: Talking to Bitcoind with C](16_0_Talking_to_Bitcoind.md).
+
+Or, if you want to stay focused on the command-line because you're not a programmer, you can skip to [Chapter Nineteen: Understanding Your Lightning Setup](19_0_Understanding_Your_Lightning_Setup.md) to continue your command-line education with the Lightning Network.


### PR DESCRIPTION
The link to chapter 15 was obviated after the last update.
This commit tries to include that link following the same format used
in the section "What's Next?" from chapter 13.3.
