### PR TITLE
fix typo on sending coins the easy way file

### DIFF
--- a/04_1_Sending_Coins_The_Easy_Way.md
+++ b/04_1_Sending_Coins_The_Easy_Way.md
@@ -32,7 +32,7 @@ $ bitcoind -daemon
 
 ## Get an Address
 
-You need somewhere to send your coins to. Usually, someone would send you an address, and perhaps give you a signature to prove they own that address. Alternatively, they might give you a QR code to scan, so that you can't make mistakes when typing in the address. In our case, we're going to send coins to `n2eMqTT929pb1RDNuqEnxdaLau1rxy3efi`, which is a return address for an old Tesetnet faucet.
+You need somewhere to send your coins to. Usually, someone would send you an address, and perhaps give you a signature to prove they own that address. Alternatively, they might give you a QR code to scan, so that you can't make mistakes when typing in the address. In our case, we're going to send coins to `n2eMqTT929pb1RDNuqEnxdaLau1rxy3efi`, which is a return address for an old Testnet faucet.
 
 > :book: ***What is a QR code?*** A QR code is just an encoding of a Bitcoin address. Many wallets will generate QR codes for you, while some sites will convert from an address to a QR code. Obviously, you should only accept a QR code from a site that you absolutely trust. A payer can use a bar-code scanner to read in the QR code, then pay to it.
 


### PR DESCRIPTION
fix typo on sending coins the easy way file
It was "Tesenet", changed it to "Testnet".