### PR TITLE
Left out word on 04 6

### DIFF
--- a/04_1_Sending_Coins_The_Easy_Way.md
+++ b/04_1_Sending_Coins_The_Easy_Way.md
@@ -32,7 +32,7 @@ $ bitcoind -daemon
 
 ## Get an Address
 
-You need somewhere to send your coins to. Usually, someone would send you an address, and perhaps give you a signature to prove they own that address. Alternatively, they might give you a QR code to scan, so that you can't make mistakes when typing in the address. In our case, we're going to send coins to `n2eMqTT929pb1RDNuqEnxdaLau1rxy3efi`, which is a return address for an old Tesetnet faucet.
+You need somewhere to send your coins to. Usually, someone would send you an address, and perhaps give you a signature to prove they own that address. Alternatively, they might give you a QR code to scan, so that you can't make mistakes when typing in the address. In our case, we're going to send coins to `n2eMqTT929pb1RDNuqEnxdaLau1rxy3efi`, which is a return address for an old Testnet faucet.
 
 > :book: ***What is a QR code?*** A QR code is just an encoding of a Bitcoin address. Many wallets will generate QR codes for you, while some sites will convert from an address to a QR code. Obviously, you should only accept a QR code from a site that you absolutely trust. A payer can use a bar-code scanner to read in the QR code, then pay to it.
 

--- a/04_6_Creating_a_Segwit_Transaction.md
+++ b/04_6_Creating_a_Segwit_Transaction.md
@@ -235,7 +235,7 @@ $ bitcoin-cli -named gettransaction txid="33173618421804343e8f6cc21316d97a24f743
 
 ## Send a SegWit Transaction The Hard Way
 
-You can similarly fund a transaction with a Bech32 address with no difference to the techniques you've learned so far. Here's an exactly of doing so with a complete raw transaction:
+You can similarly fund a transaction with a Bech32 address with no difference to the techniques you've learned so far. Here's an example of doing so with a complete raw transaction:
 ```
 $ changeaddress=$(bitcoin-cli getrawchangeaddress)
 $ echo $changeaddress


### PR DESCRIPTION
You can similarly fund a transaction with a Bech32 address with no difference to the techniques you've learned so far. Here's an exactly of doing so with a complete raw transaction:

This line feels like it's missing its exact word. I created a typo pr for it.